### PR TITLE
fix 404s in 'Surviving the Storms' talk

### DIFF
--- a/talks/_posts/2015-01-01-surviving-the-storms.html
+++ b/talks/_posts/2015-01-01-surviving-the-storms.html
@@ -3,7 +3,7 @@ layout: slides
 section: talks
 title: Surviving the Storms
 permalink: talks/storms
-contentpath : ../content/storms/
+contentpath : /talks/content/storms/
 ---
 
 <section data-state="at-slide">
@@ -17,7 +17,7 @@ contentpath : ../content/storms/
 </section>
 
 <section>
-  <img src="../content/Fixing-StackOverflow.jpg" class="plain" />
+  <img src="content/Fixing-StackOverflow.jpg" class="plain" />
 </section>
 
 <section>


### PR DESCRIPTION
Content images are 404 at http://nickcraver.com/talks/storms#/.

Who likes `404` anyway? :wink: 
